### PR TITLE
Store Proxy Usage Stats to disk for persistence across restarts

### DIFF
--- a/instance/usage.go
+++ b/instance/usage.go
@@ -3,6 +3,8 @@ package instance
 import (
 	"sync"
 	"time"
+
+	"copilot-go/store"
 )
 
 const usageWindowDuration = 1 * time.Hour
@@ -34,6 +36,38 @@ var (
 	usageMapMu sync.RWMutex
 )
 
+// LoadUsage restores persisted usage stats from disk into usageMap.
+// Called once at startup from main.go.
+func LoadUsage() {
+	persisted := store.LoadUsageStats()
+	now := time.Now()
+
+	usageMapMu.Lock()
+	defer usageMapMu.Unlock()
+
+	for accountID, accData := range persisted {
+		au := &AccountUsage{}
+		for _, rec := range accData.Records {
+			t, err := time.Parse(time.RFC3339, rec.At)
+			if err != nil {
+				continue
+			}
+			au.records = append(au.records, usageRecord{At: t, Failed: rec.Failed, Is429: rec.Is429})
+		}
+		// Trim stale records so GetUsageSnapshot returns correct counts on startup.
+		au.mu.Lock()
+		au.trimLocked(now)
+		au.mu.Unlock()
+
+		if accData.Last429 != "" && accData.Last429 != "0001-01-01T00:00:00Z" {
+			if t, err := time.Parse(time.RFC3339, accData.Last429); err == nil {
+				au.last429 = t
+			}
+		}
+		usageMap[accountID] = au
+	}
+}
+
 func getOrCreateUsage(accountID string) *AccountUsage {
 	usageMapMu.RLock()
 	u, ok := usageMap[accountID]
@@ -59,15 +93,40 @@ func RecordRequest(accountID string, failed bool, is429 bool) {
 	now := time.Now()
 
 	u.mu.Lock()
-	defer u.mu.Unlock()
-
 	u.records = append(u.records, usageRecord{At: now, Failed: failed, Is429: is429})
 	if is429 {
 		u.last429 = now
 	}
-
-	// Trim old records outside the sliding window.
 	u.trimLocked(now)
+	u.mu.Unlock()
+
+	// Persist to disk asynchronously (debounced in store layer).
+	persistUsage()
+}
+
+// persistUsage serialises the current usageMap and triggers an async save.
+func persistUsage() {
+	usageMapMu.RLock()
+	accounts := make(map[string]store.PersistedUsageAccount, len(usageMap))
+	for id, au := range usageMap {
+		au.mu.Lock()
+		recs := make([]store.PersistedUsageRecord, len(au.records))
+		for i, r := range au.records {
+			recs[i] = store.PersistedUsageRecord{
+				At:     r.At.Format(time.RFC3339),
+				Failed: r.Failed,
+				Is429:  r.Is429,
+			}
+		}
+		last429 := ""
+		if !au.last429.IsZero() {
+			last429 = au.last429.Format(time.RFC3339)
+		}
+		accounts[id] = store.PersistedUsageAccount{Records: recs, Last429: last429}
+		au.mu.Unlock()
+	}
+	usageMapMu.RUnlock()
+	store.RequestSaveUsageStats(accounts)
 }
 
 // GetUsageSnapshot returns current usage stats for a single account.

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func main() {
 		log.Fatalf("Failed to initialize data paths: %v", err)
 	}
 
+	// Restore persisted usage stats from disk
+	instance.LoadUsage()
+
 	// Load proxy config and apply to HTTP clients
 	if proxyCfg, err := store.GetProxyConfig(); err == nil && proxyCfg.ProxyURL != "" {
 		config.SetProxyURL(proxyCfg.ProxyURL)

--- a/store/paths.go
+++ b/store/paths.go
@@ -35,11 +35,15 @@ func ProxyConfigFile() string {
 	return filepath.Join(AppDir, "proxy-config.json")
 }
 
+func UsageStatsFile() string {
+	return filepath.Join(AppDir, "usage-stats.json")
+}
+
 func EnsurePaths() error {
 	if err := os.MkdirAll(AppDir, 0755); err != nil {
 		return err
 	}
-	files := []string{AccountsFile(), PoolConfigFile(), AdminFile(), ModelMapFile(), ProxyConfigFile()}
+	files := []string{AccountsFile(), PoolConfigFile(), AdminFile(), ModelMapFile(), ProxyConfigFile(), UsageStatsFile()}
 	for _, f := range files {
 		if _, err := os.Stat(f); os.IsNotExist(err) {
 			if err := os.WriteFile(f, []byte("{}"), 0644); err != nil {

--- a/store/usage.go
+++ b/store/usage.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// PersistedUsageAccount represents a single account's usage data stored on disk.
+type PersistedUsageAccount struct {
+	Records []PersistedUsageRecord `json:"records"`
+	Last429 string                 `json:"last429,omitempty"` // RFC3339 or empty
+}
+
+// PersistedUsageRecord is a JSON-serializable version of instance.usageRecord.
+type PersistedUsageRecord struct {
+	At     string `json:"at"`     // RFC3339
+	Failed bool   `json:"failed"`
+	Is429  bool   `json:"is429"`
+}
+
+// persistedUsageStore is the top-level object stored in usage-stats.json.
+type persistedUsageStore struct {
+	Accounts map[string]PersistedUsageAccount `json:"accounts"`
+	SavedAt  string                          `json:"savedAt"` // RFC3339
+}
+
+var (
+	saveReq   chan map[string]PersistedUsageAccount
+	saveReqMu atomic.Bool // ensures channel is created only once
+)
+
+// getSaveReqChan returns the save request channel, creating it exactly once.
+func getSaveReqChan() chan map[string]PersistedUsageAccount {
+	if !saveReqMu.Load() {
+		if saveReqMu.CompareAndSwap(false, true) {
+			saveReq = make(chan map[string]PersistedUsageAccount, 1)
+			go saveLoop()
+		}
+	}
+	return saveReq
+}
+
+// saveLoop runs in a single background goroutine, debouncing saves every 5 seconds.
+func saveLoop() {
+	var pending map[string]PersistedUsageAccount
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	for {
+		select {
+		case data, ok := <-saveReq:
+			if !ok {
+				// Channel closed — flush final save
+				if pending != nil {
+					saveToFile(pending)
+				}
+				return
+			}
+			pending = data
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(5 * time.Second)
+
+		case <-timer.C:
+			if pending != nil {
+				saveToFile(pending)
+				pending = nil
+			}
+		}
+	}
+}
+
+// saveToFile writes usage stats to disk (called only from the saveLoop goroutine).
+func saveToFile(accounts map[string]PersistedUsageAccount) {
+	store := persistedUsageStore{
+		Accounts: accounts,
+		SavedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(UsageStatsFile(), data, 0644)
+}
+
+// LoadUsageStats loads persisted usage stats from disk and returns them.
+// Called once at startup from instance.LoadUsage (outside the saveLoop goroutine).
+func LoadUsageStats() map[string]PersistedUsageAccount {
+	data, err := os.ReadFile(UsageStatsFile())
+	if err != nil || len(data) == 0 || string(data) == "{}" {
+		return make(map[string]PersistedUsageAccount)
+	}
+
+	var s persistedUsageStore
+	if err := json.Unmarshal(data, &s); err != nil {
+		return make(map[string]PersistedUsageAccount)
+	}
+	if s.Accounts == nil {
+		s.Accounts = make(map[string]PersistedUsageAccount)
+	}
+	return s.Accounts
+}
+
+// RequestSaveUsageStats sends a save request to the background goroutine.
+// Safe to call from multiple goroutines.
+func RequestSaveUsageStats(accounts map[string]PersistedUsageAccount) {
+	// Clone the data so the caller retains ownership.
+	clone := make(map[string]PersistedUsageAccount, len(accounts))
+	for k, v := range accounts {
+		clone[k] = v
+	}
+
+	// Non-blocking send. If the channel is full, skip this save — the next
+	// one will carry the latest data anyway.
+	select {
+	case getSaveReqChan() <- clone:
+	default:
+	}
+}


### PR DESCRIPTION
- Fix: Proxy Usage Stats now persists to usage-stats.json on disk instead of only in-memory
- Stats survive container/server restarts instead of resetting to 0