### PR TITLE
fix: resolve web console infinite redirect issue

### DIFF
--- a/handler/console_api.go
+++ b/handler/console_api.go
@@ -28,9 +28,8 @@ func RegisterConsoleAPI(r *gin.Engine, proxyPort int) {
 	if webDist != "" {
 		// Development: serve from filesystem
 		r.Static("/assets", filepath.Join(webDist, "assets"))
-		r.StaticFile("/", filepath.Join(webDist, "index.html"))
 		r.NoRoute(func(c *gin.Context) {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api") && !strings.HasPrefix(c.Request.URL.Path, "/assets") {
 				c.File(filepath.Join(webDist, "index.html"))
 			}
 		})
@@ -42,12 +41,14 @@ func RegisterConsoleAPI(r *gin.Engine, proxyPort int) {
 		} else {
 			assetsFS, _ := fs.Sub(distFS, "assets")
 			r.StaticFS("/assets", http.FS(assetsFS))
-			r.GET("/", func(c *gin.Context) {
-				c.FileFromFS("/index.html", http.FS(distFS))
-			})
 			r.NoRoute(func(c *gin.Context) {
-				if !strings.HasPrefix(c.Request.URL.Path, "/api") {
-					c.FileFromFS("/index.html", http.FS(distFS))
+				if !strings.HasPrefix(c.Request.URL.Path, "/api") && !strings.HasPrefix(c.Request.URL.Path, "/assets") {
+					data, err := fs.ReadFile(distFS, "index.html")
+					if err != nil {
+						c.String(http.StatusInternalServerError, "failed to load index.html")
+						return
+					}
+					c.Data(http.StatusOK, "text/html; charset=utf-8", data)
 				}
 			})
 		}


### PR DESCRIPTION
The Gin framework's FileFromFS returns a 301 redirect to './' when accessing '/', causing browsers to show 'too many redirects' error.

This fix:
- Removes the problematic StaticFile and GET '/' routes
- Uses fs.ReadFile to directly return index.html content
- Adds /assets path check to NoRoute handler

Fixes #4