### PR TITLE
feat: add /v1/responses endpoint for GPT-5.x models

### DIFF
--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -37,6 +37,9 @@ func RegisterProxy(r *gin.Engine) {
 	// Anthropic compatible endpoints
 	r.POST("/v1/messages", proxyMessages)
 	r.POST("/v1/messages/count_tokens", proxyCountTokens)
+
+	// OpenAI Responses API endpoint
+	r.POST("/v1/responses", proxyResponses)
 }
 
 func proxyAuth() gin.HandlerFunc {
@@ -326,4 +329,59 @@ func proxyCountTokens(c *gin.Context) {
 		return
 	}
 	instance.CountTokensHandler(c, resolved.State)
+}
+
+func proxyResponses(c *gin.Context) {
+	isPool, _ := c.Get("isPool")
+	maxAttempts := 1
+	if isPool == true {
+		maxAttempts = 3
+	}
+
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+		return
+	}
+
+	exclude := make(map[string]bool)
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		resolved := resolveState(c, exclude)
+		if resolved == nil {
+			return
+		}
+
+		if !checkRateLimit(c, resolved.AccountID) {
+			return
+		}
+
+		instance.RecordRequest(resolved.AccountID, false, false)
+
+		resp, proxyErr := instance.DoResponsesProxy(resolved.State, bodyBytes)
+		if proxyErr != nil {
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			instance.RecordRequest(resolved.AccountID, true, false)
+			if attempt < maxAttempts-1 {
+				exclude[resolved.AccountID] = true
+				log.Printf("Responses proxy error for account %s, retrying: %v", resolved.AccountID, proxyErr)
+				continue
+			}
+			c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("proxy request failed: %v", proxyErr)})
+			return
+		}
+
+		if isRetryableStatus(resp.StatusCode) && attempt < maxAttempts-1 {
+			is429 := resp.StatusCode == http.StatusTooManyRequests
+			instance.RecordRequest(resolved.AccountID, true, is429)
+			_ = resp.Body.Close()
+			exclude[resolved.AccountID] = true
+			log.Printf("Upstream returned %d for account %s, retrying with different account", resp.StatusCode, resolved.AccountID)
+			continue
+		}
+
+		instance.ForwardResponsesResponse(c, resp)
+		return
+	}
 }

--- a/instance/responses.go
+++ b/instance/responses.go
@@ -1,0 +1,75 @@
+package instance
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"copilot-go/config"
+	"copilot-go/store"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DoResponsesProxy forwards requests directly to GitHub Copilot /responses endpoint.
+func DoResponsesProxy(state *config.State, bodyBytes []byte) (*http.Response, error) {
+	// Convert model ID
+	var payload map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &payload); err == nil {
+		if model, ok := payload["model"].(string); ok {
+			payload["model"] = store.ToCopilotID(model)
+			bodyBytes, _ = json.Marshal(payload)
+		}
+	}
+
+	extraHeaders := make(http.Header)
+	extraHeaders.Set("X-Initiator", "user")
+
+	return ProxyRequestWithBytes(state, "POST", "/responses", bodyBytes, extraHeaders, false)
+}
+
+// ForwardResponsesResponse forwards the upstream response directly to client.
+func ForwardResponsesResponse(c *gin.Context, resp *http.Response) {
+	defer func() { _ = resp.Body.Close() }()
+
+	contentType := resp.Header.Get("Content-Type")
+	isStream := strings.Contains(contentType, "text/event-stream")
+
+	if isStream {
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		c.Header("X-Accel-Buffering", "no")
+		c.Status(resp.StatusCode)
+
+		reader := bufio.NewReaderSize(resp.Body, 10*1024*1024)
+		c.Stream(func(w io.Writer) bool {
+			line, err := reader.ReadBytes('\n')
+			if len(line) > 0 {
+				if _, writeErr := w.Write(line); writeErr != nil {
+					return false
+				}
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					log.Printf("Responses stream read error: %v", err)
+				}
+				return false
+			}
+			return true
+		})
+	} else {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read response"})
+			return
+		}
+		c.Data(resp.StatusCode, "application/json", body)
+	}
+}


### PR DESCRIPTION
Add support for GitHub Copilot's /responses API endpoint to enable access to newer models like gpt-5.4, gpt-5.3-codex that are not available through /chat/completions.

Changes:
- Add instance/responses.go with DoResponsesProxy and ForwardResponsesResponse
- Add /v1/responses route in handler/proxy.go
- Forward requests directly to GitHub Copilot /responses endpoint