### PR TITLE
fix: filter empty reasoning output items for client compatibility

### DIFF
--- a/instance/responses.go
+++ b/instance/responses.go
@@ -39,37 +39,68 @@ func ForwardResponsesResponse(c *gin.Context, resp *http.Response) {
 	isStream := strings.Contains(contentType, "text/event-stream")
 
 	if isStream {
-		c.Header("Content-Type", "text/event-stream")
-		c.Header("Cache-Control", "no-cache")
-		c.Header("Connection", "keep-alive")
-		c.Header("X-Accel-Buffering", "no")
-		c.Status(resp.StatusCode)
+		forwardResponsesStream(c, resp)
+	} else {
+		forwardResponsesNonStream(c, resp)
+	}
+}
 
-		reader := bufio.NewReaderSize(resp.Body, 10*1024*1024)
-		c.Stream(func(w io.Writer) bool {
-			line, err := reader.ReadBytes('\n')
-			if len(line) > 0 {
-				if _, writeErr := w.Write(line); writeErr != nil {
-					return false
-				}
-				if flusher, ok := w.(http.Flusher); ok {
-					flusher.Flush()
-				}
-			}
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("Responses stream read error: %v", err)
-				}
+func forwardResponsesStream(c *gin.Context, resp *http.Response) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(resp.StatusCode)
+
+	reader := bufio.NewReaderSize(resp.Body, 10*1024*1024)
+	c.Stream(func(w io.Writer) bool {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {if _, writeErr := w.Write(line); writeErr != nil {
 				return false
 			}
-			return true
-		})
-	} else {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read response"})
-			return
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
 		}
-		c.Data(resp.StatusCode, "application/json", body)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("Responses stream read error: %v", err)
+			}
+			return false
+		}
+		return true
+	})
+}
+
+func forwardResponsesNonStream(c *gin.Context, resp *http.Response) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read response"})
+		return
 	}
+
+	// Try to filter out empty reasoning items for better client compatibility
+	var respData map[string]interface{}
+	if err := json.Unmarshal(body, &respData); err == nil {
+		if output, ok := respData["output"].([]interface{}); ok {
+			filtered := make([]interface{}, 0)
+			for _, item := range output {
+				if m, ok := item.(map[string]interface{}); ok {
+					// Skip empty reasoning items (Copilot doesn't expose reasoning content)
+					if itemType, _ := m["type"].(string); itemType == "reasoning" {
+						if summary, _ := m["summary"].([]interface{}); len(summary) == 0 {
+							continue // Skip empty reasoning
+						}
+					}
+					filtered = append(filtered, item)
+				}
+			}
+			respData["output"] = filtered
+			if filteredBody, err := json.Marshal(respData); err == nil {
+				body = filteredBody
+			}
+		}
+	}
+
+	c.Data(resp.StatusCode, "application/json", body)
 }


### PR DESCRIPTION
GitHub Copilot API returns reasoning items with empty summary array(encrypted content not exposed). This causes clients like opencode to fail when trying to parse reasoning content.

This fix filters out empty reasoning output items in non-streaming responses while preserving reasoning_tokens in usage stats.

Changes:
- Filter empty reasoning items in response output
- Compatible with opencode and other clients