### PR TITLE
Fix web console redirect loop by disabling Gin path redirects

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,13 @@ func main() {
 	go func() {
 		defer wg.Done()
 		webEngine := gin.New()
+
+		// Prevent Gin's automatic path normalization redirects from causing redirect loops
+		// for the SPA web console (e.g. clients receiving `Location: ./` on `/`).
+		webEngine.RedirectTrailingSlash = false
+		webEngine.RedirectFixedPath = false
+		webEngine.RemoveExtraSlash = false
+
 		if *verbose {
 			webEngine.Use(gin.Logger())
 		}


### PR DESCRIPTION
## Problem
In Docker/prod, the web console on `:3000` responds with an infinite redirect loop:
- `GET /` and `GET /index.html` return `301 Location: ./` repeatedly.
- API routes like `GET /api/config` return `200`, so the server is up, but the SPA cannot load.

## Root cause
Gin's automatic path normalization redirects (fixed-path / trailing-slash / extra-slash) can fire before the SPA `NoRoute` handler and produce a broken relative redirect (`Location: ./`), preventing `index.html` from being served.

## Fix
Disable Gin path normalization redirects for the Web Console engine:
- `RedirectTrailingSlash = false`
- `RedirectFixedPath = false`
- `RemoveExtraSlash = false`

Proxy engine is unchanged.

## How to verify
Inside the container:
- `curl -i http://127.0.0.1:3000/` should return `200 text/html`
- `curl -i http://127.0.0.1:3000/api/config` should return `200 application/json`